### PR TITLE
Add rule to TOS that enforces nsfw content to be marked as such

### DIFF
--- a/static/legal/tos.txt
+++ b/static/legal/tos.txt
@@ -42,7 +42,9 @@ administrator.
      otherwise hateful or slanderous behaviour.
   5. Incel, alt-right, KKK, Nazi, and other hateful ideologies are not allowed.
      Go back to Parler and complain how this is an SJW site. We don't care.
-  6. This site does not support "cancel culture". Give people the benefit of the
+  6. Any content shared on the site that contains mature material should be
+     labeled as such using the built-in "nsfw" toggle shown when making molts.
+  7. This site does not support "cancel culture". Give people the benefit of the
      doubt and don't brigade them for their minor mistakes. People grow and this
      site encourages that.
 

--- a/static/legal/tos.txt
+++ b/static/legal/tos.txt
@@ -42,11 +42,11 @@ administrator.
      otherwise hateful or slanderous behaviour.
   5. Incel, alt-right, KKK, Nazi, and other hateful ideologies are not allowed.
      Go back to Parler and complain how this is an SJW site. We don't care.
-  6. Any content shared on the site that contains mature material should be
-     labeled as such using the built-in "nsfw" toggle shown when making molts.
-  7. This site does not support "cancel culture". Give people the benefit of the
+  6. This site does not support "cancel culture". Give people the benefit of the
      doubt and don't brigade them for their minor mistakes. People grow and this
      site encourages that.
+  7. Any content shared on the site that contains mature material should be
+     labeled as such using the built-in "nsfw" toggle shown when making molts.
 
 # 3. Privacy
 


### PR DESCRIPTION
As it stands the TOS does not currently prohibit NSFW content being publicly posted without the `nsfw` toggle, this simply adds a rule enforcing users to do so when posting NSFW content. closes #144.