### PR TITLE
Add captcha to login page, if enabled

### DIFF
--- a/crabber.py
+++ b/crabber.py
@@ -258,6 +258,8 @@ def notifications():
 @app.route("/login/", methods=("GET", "POST"))
 def login():
     if request.method == "POST":
+        if not captcha.verify():
+            return utils.show_error("Captcha verification failed")
         email, password = request.form.get("email").strip().lower(), request.form.get(
             "password"
         )

--- a/templates/login.html
+++ b/templates/login.html
@@ -23,10 +23,15 @@
             <label for="login-password">Password</label>
             <input type="password" name="password" class="form-control" id="login-password" required aria-required>
         </div>
-        <div class="form-group form-check mt-4" title="We don't discriminate!">
-            <input type="checkbox" class="form-check-input" id="is-robot">
-            <label class="form-check-label" for="is-robot">I am a robot</label>
-        </div>
+
+        {% if config['HCAPTCHA_ENABLED'] %}
+            <div class="form-group mt-4">{{ hcaptcha }}</div>
+        {% else %}
+            <div class="form-group form-check mt-4" title="We don't discriminate!">
+                <input type="checkbox" class="form-check-input" id="is-robot">
+                <label class="form-check-label" for="is-robot">I am a robot</label>
+            </div>
+        {% endif %}
 
         <div class="d-flex align-items-center mt-4">
             <button type="submit" class="login-btn btn btn-primary rounded-pill mr-4">


### PR DESCRIPTION
Currently signups are protected from spam by hCatpcha, but logins are not, so users are able to endlessly hit the login page, and thus the database. This simply adds captcha and verification to the login page as well, unfortunately when captcha is enabled we'll have to hide the joke "I am a robot" checkbox because it could be confusing to users.